### PR TITLE
fix(layout): preserve Esc keymap on reopen

### DIFF
--- a/lua/package-ui/ui/layout.lua
+++ b/lua/package-ui/ui/layout.lua
@@ -347,6 +347,11 @@ function M.close_all_windows()
 end
 
 function M.setup()
+  if #windows ~= 0 then
+    M.close_all_windows()
+    return
+  end
+
   windows = {}
 
   setup_event_listeners()


### PR DESCRIPTION
Calling the PackageUI command multiple times broke the Esc key because window-specific key mappings were lost after closing. 

This fix checks if the windows are already open and close them, giving the command toggle behavior.

Steps to reproduce (before the fix):

    - Run :PackageUI

    - Run :PackageUI again
    
    - Press <Esc> 